### PR TITLE
Force TLSv1.1 to work around OTP bug

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R1[456]|17"}.
+{require_otp_vsn, "R1[456]|17|18"}.
 {erl_opts, [{src_dirs, ["src", "test"]},
             warn_unused_vars,
             warn_export_all,

--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -86,7 +86,8 @@ ssl_opts(Connection) ->
     case Connection#apns_connection.cert_password of
       undefined -> [];
       Password -> [{password, Password}]
-    end,
+    end ++
+    [{versions,['tlsv1']}], %% Work around OTP TLS bug: https://github.com/inaka/apns4erl/issues/57
   [{mode, binary} | Opts].
 
 %% @hidden

--- a/src/apns_connection.erl
+++ b/src/apns_connection.erl
@@ -86,8 +86,7 @@ ssl_opts(Connection) ->
     case Connection#apns_connection.cert_password of
       undefined -> [];
       Password -> [{password, Password}]
-    end ++
-    [{versions,['tlsv1']}], %% Work around OTP TLS bug: https://github.com/inaka/apns4erl/issues/57
+    end,
   [{mode, binary} | Opts].
 
 %% @hidden


### PR DESCRIPTION
http://erlang.org/pipermail/erlang-questions/2015-June/084872.html

This pull request shouldn't be merged, but it is a reminder to us that we're either going to have to patch OTP (which might be easy, since supposedly it's all baked into our release build) or upgrade to R18.0.2.

https://github.com/erlang/otp/commit/ae7347bfdcab2486bb55dfe54918a0c994d8b7c7
